### PR TITLE
Add serverless migration documentation

### DIFF
--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,23 @@
+# Migration to AWS Serverless Microservices
+
+이 문서는 기존 Spring Boot 모듈러 모놀리식 애플리케이션을 AWS Serverless 기반의 마이크로서비스 아키텍처로 전환하기 위한 계획을 정리한 것입니다. 전반적인 흐름과 단계별 작업을 요약하고, 세부 내용은 하위 문서에서 다룹니다.
+
+## 목차
+
+1. [아키텍처 설계](architecture.md)
+2. [퍼시스턴스 레이어 전환](persistence-migration.md)
+3. [IaC 및 CI/CD](iac-cicd.md)
+
+## 단계별 마이그레이션 개요
+
+1. **기존 구조 분석** – `users`, `profiles`, `articles` 모듈로 구성된 모놀리식 구조와 Keycloak, PostgreSQL 사용 현황 파악
+2. **서비스 경계 정의** – 각 모듈을 독립된 마이크로서비스(Users, Profiles, Articles)로 분리하고 인증은 Cognito로 대체
+3. **코드 분리 및 리팩터링** – 공통 라이브러리를 유지하되 Lambda 실행을 위해 모듈별로 경량화
+4. **데이터베이스 분리 및 이전** – PostgreSQL 기반 JPA 엔티티를 DynamoDB 테이블로 전환
+5. **Lambda 함수 구현** – 서비스별 API 엔드포인트를 Lambda로 작성하고 API Gateway로 라우팅
+6. **데이터 마이그레이션** – 기존 DB 데이터를 새 DynamoDB 테이블로 이전
+7. **CI/CD와 인프라** – AWS CDK로 인프라를 정의하고 GitHub Actions로 배포 파이프라인 구성
+8. **테스트 및 점진적 전환** – 기능별 테스트 후 트래픽을 단계적으로 전환
+
+각 단계의 세부 설명과 고려 사항은 하위 문서를 참고하세요.
+

--- a/docs/migration/architecture.md
+++ b/docs/migration/architecture.md
@@ -1,0 +1,26 @@
+# 아키텍처 설계
+
+기존 애플리케이션은 모듈러 모놀리식 구조로 동작하며 Keycloak과 PostgreSQL을 사용합니다. 마이크로서비스 전환 후에는 AWS의 완전관리형 서비스를 활용해 다음과 같이 구성합니다.
+
+```mermaid
+graph TD
+    A[사용자] --> B(API Gateway)
+    B --> C(Users Lambda)
+    B --> D(Profiles Lambda)
+    B --> E(Articles Lambda)
+    C --> F[DynamoDB - Users]
+    D --> G[DynamoDB - Profiles]
+    E --> H[DynamoDB - Articles]
+    B -.-> I[Cognito Authorizer]
+```
+
+## 주요 컴포넌트
+
+- **API Gateway** – 모든 클라이언트 요청 진입점이며 Cognito JWT를 검증합니다.
+- **AWS Lambda** – 각 서비스(users, profiles, articles)를 독립 함수로 배포합니다.
+- **Amazon DynamoDB** – 서비스별 테이블을 사용해 데이터 스토어를 분리합니다.
+- **Amazon Cognito** – 사용자 인증 및 권한 관리 역할을 수행합니다.
+- **CloudWatch/X-Ray** – 로깅과 모니터링, 추적을 담당합니다.
+
+서비스 간 필요 시 SNS/SQS 또는 EventBridge를 통해 비동기 통신을 구현할 수 있습니다.
+

--- a/docs/migration/iac-cicd.md
+++ b/docs/migration/iac-cicd.md
@@ -1,0 +1,23 @@
+# IaC와 CI/CD 전략
+
+## AWS CDK를 활용한 인프라 구성
+
+1. 각 마이크로서비스(Lambda, API Gateway, DynamoDB, Cognito 등)를 스택 단위로 정의
+2. 스테이지(개발, 스테이징, 프로덕션)별로 파라미터를 분리하여 재사용성 확보
+3. `cdk synth`를 통해 CloudFormation 템플릿을 생성하고 `cdk deploy`로 배포
+
+## GitHub Actions를 이용한 파이프라인
+
+```mermaid
+flowchart TD
+    A[Push to main branch] --> B(Build & Test)
+    B --> C(CDK Synth)
+    C --> D(Deploy to AWS)
+```
+
+1. PR 또는 main 브랜치로의 푸시 시 Maven 빌드 및 단위 테스트 실행
+2. CDK 애플리케이션을 빌드하여 CloudFormation 템플릿 생성
+3. 필요 시 승인 단계를 거쳐 `cdk deploy` 명령으로 각 스택 배포
+
+Secrets 관리에는 GitHub Actions의 암호화된 변수와 AWS IAM 역할을 활용합니다.
+

--- a/docs/migration/persistence-migration.md
+++ b/docs/migration/persistence-migration.md
@@ -1,0 +1,29 @@
+# 퍼시스턴스 레이어 전환
+
+기존 애플리케이션은 JPA 기반으로 PostgreSQL에 데이터를 저장합니다. 마이크로서비스화와 함께 NoSQL인 DynamoDB를 사용하도록 변경합니다.
+
+## 기존 주요 엔티티
+
+- **Article**: id, authorId, slug, title, description, body, createdAt, updatedAt, tagList, favorites, comments
+- **Comment**: id, authorId, body, article, createdAt, updatedAt
+- **Favorite**: id, userId, article, createdAt
+- **Tag**: id, value, articles
+- **Follow**: id, followerId, followedId, createdAt
+
+## DynamoDB 설계안
+
+서비스별로 다음과 같이 테이블을 생성합니다.
+
+- `Users` 테이블 – Cognito 사용자 속성 외에 필요시 추가 정보를 저장
+- `Profiles` 테이블 – 팔로우 관계(`Follow`)를 파티션 키와 정렬 키 조합으로 저장
+- `Articles` 테이블 – 게시글(`Article`)을 기본 항목으로 두고 `Comments`, `Favorites`, `Tags`를 GSI 혹은 별도 테이블로 분리
+
+각 테이블의 정확한 파티션 키 및 인덱스 설계는 사용 패턴을 고려하여 세부 조정이 필요합니다.
+
+## 마이그레이션 절차
+
+1. DynamoDB 테이블 스키마 정의 및 생성 (CDK 활용)
+2. PostgreSQL에서 각 엔티티 데이터를 추출하여 변환 스크립트를 통해 DynamoDB로 적재
+3. 서비스 코드에서 JPA 의존성을 제거하고 DynamoDB SDK를 사용하도록 리포지토리 레이어 수정
+4. 데이터 일관성 검증 후 기존 데이터베이스는 읽기 전용으로 전환하고 최종 스위칭
+


### PR DESCRIPTION
## Summary
- document migration plan to AWS serverless microservices
- outline architecture using mermaid diagram
- describe DynamoDB migration strategy
- note CDK/IaC and GitHub Actions pipeline

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven)*